### PR TITLE
use navigator.sendBeacon when available

### DIFF
--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -118,16 +118,23 @@
 
   StackdriverErrorReporter.prototype.sendErrorPayload = function(payload, callback) {
     var url = baseAPIUrl + this.projectId + "/events:report?key=" + this.apiKey;
+    var CONTENT_TYPE = 'application/json; charset=UTF-8';
+    var payloadString = JSON.stringify(payload);
+    var end = typeof callback === 'function' ? callback : function () {};
+
+    // Check if we can use sendBeacon
+    if (typeof Blob !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+      // create blob to set content type to JSON - needed for correct HTTP header
+      var blob = new Blob([payloadString], { type: CONTENT_TYPE });
+      navigator.sendBeacon(url, blob);
+      return end();
+    }
 
     var xhr = new XMLHttpRequest();
     xhr.open('POST', url, true);
-    xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
-    xhr.onloadend = function() {
-      return typeof callback === 'function' && callback();
-    };
-    xhr.onerror = function(e) {
-      return typeof callback === 'function' && callback(e);
-    };
-    xhr.send(JSON.stringify(payload));
+    xhr.setRequestHeader('Content-Type', CONTENT_TYPE);
+    xhr.onloadend = end;
+    xhr.onerror = end;
+    xhr.send(payloadString);
   };
 })(this);


### PR DESCRIPTION
`sendBeacon` designed specially for that use cases and available in most versions of Google Chrome and Firefox