### PR TITLE
Handle failures to process stacktraces.

### DIFF
--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -113,6 +113,14 @@
         payload.message += ['    at ', stack[s].getFunctionName(), ' (', stack[s].getFileName(), ':', stack[s].getLineNumber() ,':', stack[s].getColumnNumber() , ')'].join('');
       }
       that.sendErrorPayload(payload, callback);
+    }, function(reason) {
+      // Failure to extract stacktrace
+      payload.message = [
+        'Error extracting stack trace: ', reason, '\n',
+        err.toString(), '\n',
+        '    (', err.file, ':', err.line, ':', err.column, ')',
+      ].join('');
+      that.sendErrorPayload(payload, callback);
     });
   };
 


### PR DESCRIPTION
This can manifest as "Unhandled promise rejection" or "Cannot parse given Error object" messages in the browser, that occur *while* trying to run the stackdriver-errors-js code...though you'd never know it unless you were also running another javascript-error-reporting system (like I was)

These breaking exceptions can happen with stacktraces like "Access Denied", which stacktrace.js fails on:
https://github.com/stacktracejs/stacktrace.js/issues/170