### PR TITLE
Allow more details context config in reports.

### DIFF
--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -30,6 +30,8 @@
   /**
    * Initialize the StackdriverErrorReporter object.
    * @param {Object} config - the init configuration.
+   * @param {Object} [config.context={}] - the context in which the error occurred.
+   * @param {string} [config.context.user] - the user who caused or was affected by the error.
    * @param {String} config.key - the API key to use to call the API.
    * @param {String} config.projectId - the Google Cloud Platform project ID to report errors to.
    * @param {String} [config.service=web] - service identifier.
@@ -47,6 +49,7 @@
 
     this.apiKey = config.key;
     this.projectId = config.projectId;
+    this.context = config.context || {};
     this.serviceContext = {service: config.service || 'web'};
     if(config.version) {
       this.serviceContext.version = config.version;
@@ -84,11 +87,10 @@
 
     var payload = {};
     payload.serviceContext = this.serviceContext;
-    payload.context = {
-      httpRequest: {
-        userAgent: window.navigator.userAgent,
-        url: window.location.href
-      }
+    payload.context = this.context;
+    payload.context.httpRequest = {
+      userAgent: window.navigator.userAgent,
+      url: window.location.href
     };
 
     var firstFrameIndex = 0;

--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -140,4 +140,13 @@
     };
     xhr.send(JSON.stringify(payload));
   };
+
+  /**
+   * Set the user for the current context.
+   *
+   * @param {string} user - the unique identifier of the user (can be ID, email or custom token) or `undefined` if not logged in.
+   */
+  StackdriverErrorReporter.prototype.setUser = function(user) {
+    this.context.user = user;
+  };
 })(this);

--- a/test/test.js
+++ b/test/test.js
@@ -68,6 +68,16 @@ describe('Initialization', function () {
    expect(function() {errorHandler.start({key:'key'});}).to.throw(Error, /project/);
  });
 
+ it('should have default context', function () {
+   errorHandler.start({key:'key', projectId:'projectId'});
+   expect(errorHandler.context).to.eql({});
+ });
+
+ it('should allow to specify a default context', function () {
+   errorHandler.start({context: { user: '1234567890' }, key:'key', projectId:'projectId'});
+   expect(errorHandler.context).to.eql({ user: '1234567890' });
+ });
+
 });
 
 describe('Disabling', function () {
@@ -145,6 +155,16 @@ describe('Unhandled exceptions', function () {
     }
   });
 
+});
+
+describe('Setting user', function() {
+  it('should set the user in the context', function () {
+    errorHandler.start({key:'key', projectId:'projectId'});
+    errorHandler.setUser('1234567890');
+    expect(errorHandler.context.user).to.equal('1234567890');
+    errorHandler.setUser();
+    expect(errorHandler.context.user).to.equal(undefined);
+  });
 });
 
 afterEach(function() {


### PR DESCRIPTION
So far, the payload was only sending a limited set of context information related to the httpRequest.
We can now, for example, specify a user when starting the error reporter.