### PR TITLE
update stacktrace version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "sinon": "^1.17.4"
   },
   "dependencies": {
-    "stacktrace-js": "^1.3.0"
+    "stacktrace-js": "^2.0.0"
   }
 }


### PR DESCRIPTION
Update to v2.0.0

I ran the tests and all seems good. From what I could gather, it's only really used for the `.fromError` and the functions used in there haven't changed really (getFunctionName etc...).