### PR TITLE
Fix stack trace if there are anonymous functions in stack trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,10 +217,10 @@ import errorHandler from './errorHandlerUtility';
 
 ## Developing the library
 
-Install developer dependencies with `npm install --dev` and install `gulp` with `npm install -g gulp`
+Install developer dependencies with `npm install --dev`
 
-* Run `gulp` to test your changes.
-* Run `gulp dist` generates the minified version.
+* Run `npm test` or `yarn run test` to test your changes.
+* Run `npm run dist` or `yarn run dist` generates the minified version.
 
 Start a web server at the root of this repo and open `demo/demo.html` to test reporting errors from the local library with your API key and project ID.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stackdriver-errors-js",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,12 @@
     "type": "git",
     "url": "https://github.com/GoogleCloudPlatform/stackdriver-errors-js"
   },
+  "scripts": {
+    "test": "gulp",
+    "dist": "gulp dist",
+    "lint": "gulp lint",
+    "start": "gulp min-demo"
+  },
   "keywords": [
     "stackdriver",
     "error",

--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -112,7 +112,9 @@
         payload.message += '\n';
         // Reconstruct the stackframe to a JS stackframe as expected by Error Reporting parsers.
         // stack[s].source should not be used because not populated when created from source map.
-        payload.message += ['    at ', stack[s].getFunctionName(), ' (', stack[s].getFileName(), ':', stack[s].getLineNumber() ,':', stack[s].getColumnNumber() , ')'].join('');
+        // 
+        // If functionName or methodName isn't available <anonymous> will be used as the name.
+        payload.message += ['    at ', stack[s].getFunctionName() || '<anonymous>', ' (', stack[s].getFileName(), ':', stack[s].getLineNumber() ,':', stack[s].getColumnNumber() , ')'].join('');
       }
       that.sendErrorPayload(payload, callback);
     }, function(reason) {

--- a/test/test.html
+++ b/test/test.html
@@ -16,7 +16,6 @@
   <script src="../stackdriver-errors.js"></script>
   <script src="test.js"></script>
   <script>
-    //mocha.allowUncaught()
     mocha.run();
   </script>
 </body>

--- a/test/test.js
+++ b/test/test.js
@@ -141,11 +141,13 @@ describe('Reporting errors', function () {
     }
   });
 
-  it('should extract and send <anonymous> in stack traces', function (done) {
+  it('should set in stack traces when frame is anonymous', function (done) {
     var message = 'custom message';
     // PhantomJS only attaches a stack to thrown errors
     try {
-      throwError(message)
+      (function () {
+        throw new TypeError(message);
+      })()
     } catch(e) {
       errorHandler.report(e, function() {
         expectRequestWithMessage('<anonymous>');

--- a/test/test.js
+++ b/test/test.js
@@ -18,12 +18,21 @@ var expect = chai.expect;
 var errorHandler;
 var xhr, requests;
 
-/** Helper function testing if a given message has been reported */
+/** 
+ * Helper function testing if a given message has been reported
+ */
 function expectRequestWithMessage(message) {
   expect(requests.length).to.equal(1);
   var sentBody = JSON.parse(requests[0].requestBody);
   expect(sentBody).to.include.keys('message');
   expect(sentBody.message).to.contain(message);
+}
+
+/**
+ * Helper for testing call stack reporting
+ */
+function throwError(message) {
+  throw new TypeError(message);
 }
 
 beforeEach(function() {
@@ -114,6 +123,32 @@ describe('Reporting errors', function () {
     } catch(e) {
       errorHandler.report(e, function() {
         expectRequestWithMessage(message);
+        done();
+      });
+    }
+  });
+
+  it('should extract and send functionName in stack traces', function (done) {
+    var message = 'custom message';
+    // PhantomJS only attaches a stack to thrown errors
+    try {
+      throwError(message)
+    } catch(e) {
+      errorHandler.report(e, function() {
+        expectRequestWithMessage('throwError');
+        done();
+      });
+    }
+  });
+
+  it('should extract and send <anonymous> in stack traces', function (done) {
+    var message = 'custom message';
+    // PhantomJS only attaches a stack to thrown errors
+    try {
+      throwError(message)
+    } catch(e) {
+      errorHandler.report(e, function() {
+        expectRequestWithMessage('<anonymous>');
         done();
       });
     }


### PR DESCRIPTION
* Add `<anonymous>` in stack trace if there is no functionName
* Add command using scripts in package.json
* Add tests
* Remove unused code in test.html
* Update version in package lock
* Update readme to include test instructions

Problem with issue #21 is due to errors thrown in anonymous scope, [V8 stack trace format](https://github.com/v8/v8/wiki/Stack-Trace-API#appendix-stack-trace-format) expects `<anonymous>` in this case. I've added a simple fallback for this case and some tests to try it (I'm not 100% happy with anonymous one but I have no idea how to throw an error in the global anonymous scope from inside the tests). Still, I think we should review the whole V8 format and check if we cover every case and definitely write tests to cover all the cases.

As for other changes, I've added scripts commands in `package.json` so no global Gulp required anymore — Readme updated too.