### PR TITLE
Fix error handler utility example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ if (environment === 'production') {
   });
 
 } else {
-  errorHandler = console.error;
+  errorHandler = {report: console.error};
 }
 
 export default errorHandler;


### PR DESCRIPTION
I believe the `errorHandlerUtility` example needs to have both production & local conform to the expected `report` shape to work properly.