### PR TITLE
Fix broken tests on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "node"
-  
-before_script:
-  - npm install -g gulp
-script: gulp test
+  - "9"
+
+script: npm test


### PR DESCRIPTION
Fixed: Make Travis Node version fixed, switch to `npm test` command, so we use package.json Gulp 3.9.1 version