### PR TITLE
Read dependency sourcemaps on build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,7 +42,7 @@ gulp.task('test', function () {
 
 gulp.task('dist', function() {
   return gulp.src(dependencies.concat(SRC_FILE))
-    .pipe(sourcemaps.init())
+    .pipe(sourcemaps.init({ loadMaps: true }))
     .pipe(concat(SRC_FILE.replace('.js', '-concat.js')))
     // This will output the non-minified version
     .pipe(gulp.dest(DEST))


### PR DESCRIPTION
No effect on the contents of the minified source, but stripping the embedded sourcemap greatly reduces the size of the plain concat file and the final sourcemap generated.

### before

```
dist
├── [       4096]  maps
│   └── [     556070]  stackdriver-errors-concat.min.js.map
├── [     481871]  stackdriver-errors-concat.js
└── [      50790]  stackdriver-errors-concat.min.js
```

### after

```
dist/
├── [       4096]  maps
│   └── [     464091]  stackdriver-errors-concat.min.js.map
├── [     192267]  stackdriver-errors-concat.js
└── [      50790]  stackdriver-errors-concat.min.js
```