### PR TITLE
 Simplify new version release steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,12 +48,12 @@ the one above, the [Software Grant and Corporate Contributor License Agreement].
 
 ## Creating a new release
 
-* find and replace the version number package.json and commit
-* create a new git tag: `git tag v0.0.x`
-* push tag `git push --tags`
-* Create a [GitHub Release]
-* update on npm: `npm publish`
-* update the README to use this new published version in setup instructions and commit
+From master branch with all required changes landed and pulled:
+
+* Run `npm version minor -m 'Release %s'` with semver component as needed.
+* Push commit and new tag with `git push --tags`.
+* Create a [GitHub Release].
+* Publish new package to npm registry with `npm publish`.
 
 
 [npm]: https://www.npmjs.com/

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "Experimental client-side JavaScript library to report errors to Stackdriver Error Reporting",
   "main": "stackdriver-errors.js",
   "scripts": {
+    "clean": "rimraf dist/",
     "dist": "gulp dist",
     "lint": "eslint --ignore-path .gitignore .",
     "prebuild": "npm run test",
     "prepare": "npm run dist",
+    "prepublish": "npm run clean",
     "pretest": "npm run lint",
     "start": "gulp demo && http-server ./dist -o",
     "test": "mocha -r test/setup.js test/test.js",
@@ -17,6 +19,9 @@
     "type": "git",
     "url": "https://github.com/GoogleCloudPlatform/stackdriver-errors-js"
   },
+  "files": [
+    "dist/"
+  ],
   "keywords": [
     "stackdriver",
     "error",
@@ -40,6 +45,7 @@
     "gulp-uglify": "^3.0.1",
     "http-server": "^0.11.1",
     "mocha": "^5.2.0",
+    "rimraf": "^2.6.2",
     "sinon": "^7.1.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "scripts": {
     "dist": "gulp dist",
     "lint": "eslint --ignore-path .gitignore .",
+    "prebuild": "npm run test",
     "prepare": "npm run dist",
+    "pretest": "npm run lint",
     "start": "gulp demo && http-server ./dist -o",
-    "test": "npm run lint && mocha -r test/setup.js test/test.js"
+    "test": "mocha -r test/setup.js test/test.js",
+    "version": "sed -i s/@[0-9.]\\\\{5,\\\\}/@${npm_package_version}/g README.md && git add README.md"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Suggest use of `npm version` command to bump version and create new new git tag and commit.

Use version script to update CDN url referenced in `README.md` file.

Add more pre-step scripts for basic workflows.

Add clean script and use before publication

Also limit packaged files to the common ones and newly generated
files under dist/ folder.