### PR TITLE
[pr] Use Custom HttpRequestContext from Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,18 @@ errorHandler.start({
     // disabled: true
     // Set to true to not send error reports, this can be used when developing locally.
 
-    // context: {user: 'user1'}
-    // You can set the user later using setUser()
+    // context: {
+    //   user: 'user1', // The user who caused or was affected by the crash, default unspecified, but can be set later using `setUser()`
+    //   httpRequest: {
+    //     method: 'GET', // The type of HTTP request, such as `GET`, `POST`, etc., default unspecified
+    //     url: 'https://www.google.com', // The URL Of the request, default to `window.location.href`
+    //     userAgent: 'Chrome/80.0', // The user agent information that is provided with the request, default to `window.navigator.userAgent`
+    //     refererrer: 'https://www.bing.com', // The referrer information that is provided with the request, default unspecified
+    //     responseStatusCode: 404, // The HTTP response status code for the request, default unspecified
+    //     remoteIp: The IP address from which the request originated, default unspecified
+    //   }
+    // }
+    // Context of the errored request.
 });
 ```
 

--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -144,12 +144,12 @@ function addDefaultHttpRequestContext(httpRequestContext) {
   }
   httpRequestContext.userAgent =
   httpRequestContext.userAgent === undefined
-      ? window.navigator.userAgent
-      : httpRequestContext.userAgent;
+    ? window.navigator.userAgent
+    : httpRequestContext.userAgent;
   httpRequestContext.url =
   httpRequestContext.url === undefined
-      ? window.location.href
-      : httpRequestContext.url;
+    ? window.location.href
+    : httpRequestContext.url;
   return httpRequestContext;
 }
 

--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -109,10 +109,17 @@ StackdriverErrorReporter.prototype.report = function(err, options) {
   var payload = {};
   payload.serviceContext = this.serviceContext;
   payload.context = this.context;
-  payload.context.httpRequest = {
-    userAgent: window.navigator.userAgent,
-    url: window.location.href,
-  };
+  if (payload.context.httpRequest === undefined) {
+    payload.context.httpRequest = {};
+  }
+  payload.context.httpRequest.userAgent =
+    payload.context.httpRequest.userAgent === undefined
+      ? window.navigator.userAgent
+      : payload.context.httpRequest.userAgent;
+  payload.context.httpRequest.url =
+    payload.context.httpRequest.url === undefined
+      ? window.location.href
+      : payload.context.httpRequest.url;
 
   var firstFrameIndex = 0;
   if (typeof err == 'string' || err instanceof String) {

--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -109,17 +109,7 @@ StackdriverErrorReporter.prototype.report = function(err, options) {
   var payload = {};
   payload.serviceContext = this.serviceContext;
   payload.context = this.context;
-  if (payload.context.httpRequest === undefined) {
-    payload.context.httpRequest = {};
-  }
-  payload.context.httpRequest.userAgent =
-    payload.context.httpRequest.userAgent === undefined
-      ? window.navigator.userAgent
-      : payload.context.httpRequest.userAgent;
-  payload.context.httpRequest.url =
-    payload.context.httpRequest.url === undefined
-      ? window.location.href
-      : payload.context.httpRequest.url;
+  payload.context.httpRequest = addDefaultHttpRequestContext(payload.context.httpRequest);
 
   var firstFrameIndex = 0;
   if (typeof err == 'string' || err instanceof String) {
@@ -147,6 +137,21 @@ StackdriverErrorReporter.prototype.report = function(err, options) {
       return sendErrorPayload(reportUrl, payload);
     });
 };
+
+function addDefaultHttpRequestContext(httpRequestContext) {
+  if (httpRequestContext === undefined) {
+    httpRequestContext = {};
+  }
+  httpRequestContext.userAgent =
+  httpRequestContext.userAgent === undefined
+      ? window.navigator.userAgent
+      : httpRequestContext.userAgent;
+  httpRequestContext.url =
+  httpRequestContext.url === undefined
+      ? window.location.href
+      : httpRequestContext.url;
+  return httpRequestContext;
+}
 
 function resolveError(err, firstFrameIndex) {
   // This will use sourcemaps and normalize the stack frames

--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -52,6 +52,7 @@ StackdriverErrorReporter.prototype.start = function(config) {
   this.projectId = config.projectId;
   this.targetUrl = config.targetUrl;
   this.context = config.context || {};
+  this.context.httpRequest = setupDefaultHttpRequestContext(this.context.httpRequest);
   this.serviceContext = {service: config.service || 'web'};
   if (config.version) {
     this.serviceContext.version = config.version;
@@ -109,7 +110,6 @@ StackdriverErrorReporter.prototype.report = function(err, options) {
   var payload = {};
   payload.serviceContext = this.serviceContext;
   payload.context = this.context;
-  payload.context.httpRequest = addDefaultHttpRequestContext(payload.context.httpRequest);
 
   var firstFrameIndex = 0;
   if (typeof err == 'string' || err instanceof String) {
@@ -138,7 +138,7 @@ StackdriverErrorReporter.prototype.report = function(err, options) {
     });
 };
 
-function addDefaultHttpRequestContext(httpRequestContext) {
+function setupDefaultHttpRequestContext(httpRequestContext) {
   if (httpRequestContext === undefined) {
     httpRequestContext = {};
   }

--- a/test/test.js
+++ b/test/test.js
@@ -125,8 +125,27 @@ describe('Initialization', function() {
   });
 
   it('should allow to specify a default context', function() {
-    errorHandler.start({context: {user: '1234567890'}, key: 'key', projectId: 'projectId'});
-    expect(errorHandler.context).to.eql({user: '1234567890'});
+    var method = 'GET';
+    var userAgent = 'bot';
+    var remoteIp = '123.45.67.89';
+    var user = '1234567890';
+
+    var httpRequestContext = {
+      method: method,
+      userAgent: userAgent,
+      remoteIp: remoteIp,
+    };
+
+    var context = {
+      user: '1234567890',
+      httpRequest: httpRequestContext,
+    };
+    errorHandler.start({context: context, key: 'key', projectId: 'projectId'});
+    expect(errorHandler.context).to.eql({user: user});
+    expect(errorHandler.context.httpRequest).to.eql({method: method});
+    expect(errorHandler.context.httpRequest).to.eql({userAgent: userAgent});
+    expect(errorHandler.context.httpRequest).to.eql({remoteIp: remoteIp});
+    expect(errorHandler.context.httpRequest).to.not({url: undefined});
   });
 });
 
@@ -278,35 +297,6 @@ describe('Reporting errors', function() {
       return errorHandler.report(message).then(function() {
         expectPayloadWithMessage(funcResult, message);
         expect(requests.length).to.equal(0);
-      });
-    });
-  });
-
-  describe('Custom http request context', function() {
-    it('should report error messages with custom http request context', function() {
-      var method = 'GET';
-      var userAgent = 'bot';
-      var remoteIp = '123.45.67.89';
-
-      var httpRequestContext = {
-        method: method,
-        userAgent: userAgent,
-        remoteIp: remoteIp,
-      };
-
-      var context = {
-        httpRequest: httpRequestContext,
-      };
-
-      errorHandler.start({key: 'key', projectId: 'projectId', context: context});
-
-      var message = 'Something broke!';
-      return errorHandler.report(message).then(function() {
-        expectRequestWithMessage(message);
-        expectRequestWithMessage('method: ' + method);
-        expectRequestWithMessage('userAgent: ' + userAgent);
-        expectRequestWithMessage('remoteIp: ' + remoteIp);
-        expectRequestWithMessage('url'); // specified to be window.location.href by default
       });
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -298,7 +298,7 @@ describe('Reporting errors', function() {
         httpRequest: httpRequestContext,
       };
 
-      errorHandler.start({context: context});
+      errorHandler.start({key: 'key', projectId: 'projectId', context: context});
 
       var message = 'Something broke!';
       return errorHandler.report(message).then(function() {

--- a/test/test.js
+++ b/test/test.js
@@ -122,7 +122,7 @@ describe('Initialization', function() {
   it('should have default context', function() {
     errorHandler.start({key: 'key', projectId: 'projectId'});
     expect(errorHandler.context).to.eql({httpRequest: {
-      url: window.location.url,
+      url: 'http://stackdriver-errors.test/',
       userAgent: window.navigator.userAgent,
     }});
   });
@@ -150,7 +150,7 @@ describe('Initialization', function() {
         method: method,
         userAgent: userAgent,
         remoteIp: remoteIp,
-        url: window.location.url,
+        url: 'http://stackdriver-errors.test/',
       },
     });
   });

--- a/test/test.js
+++ b/test/test.js
@@ -283,6 +283,35 @@ describe('Reporting errors', function() {
   });
 });
 
+describe('Custom http request context', function () {
+  it('should report error messages with custom http request context', function () {
+    var method = "GET";
+    var userAgent = "bot";
+    var remoteIp = "123.45.67.89";
+
+    var httpRequestContext = {
+      method: method,
+      userAgent: userAgent,
+      remoteIp: remoteIp
+    };
+
+    var context = {
+      httpRequest: httpRequestContext
+    };
+
+    errorHandler.start({ context: context });
+
+    var message = 'Something broke!';
+    return errorHandler.report(message).then(function () {
+      expectRequestWithMessage(message);
+      expectRequestWithMessage("method: " + method);
+      expectRequestWithMessage("userAgent: " + userAgent);
+      expectRequestWithMessage("remoteIp: " + remoteIp);
+      expectRequestWithMessage("url"); // specified to be window.location.href by default
+    });
+  });
+});
+
 describe('Unhandled exceptions', function() {
   it('should be reported by default', function(done) {
     errorHandler.start({key: 'key', projectId: 'projectId'});

--- a/test/test.js
+++ b/test/test.js
@@ -121,7 +121,10 @@ describe('Initialization', function() {
 
   it('should have default context', function() {
     errorHandler.start({key: 'key', projectId: 'projectId'});
-    expect(errorHandler.context).to.eql({});
+    expect(errorHandler.context).to.eql({httpRequest: {
+      url: window.location.url,
+      userAgent: window.navigator.userAgent
+    }});
   });
 
   it('should allow to specify a default context', function() {
@@ -141,11 +144,14 @@ describe('Initialization', function() {
       httpRequest: httpRequestContext,
     };
     errorHandler.start({context: context, key: 'key', projectId: 'projectId'});
-    expect(errorHandler.context).to.eql({user: user});
-    expect(errorHandler.context.httpRequest).to.eql({method: method});
-    expect(errorHandler.context.httpRequest).to.eql({userAgent: userAgent});
-    expect(errorHandler.context.httpRequest).to.eql({remoteIp: remoteIp});
-    expect(errorHandler.context.httpRequest).to.not({url: undefined});
+    expect(errorHandler.context).to.eql({
+      user: user,
+      httpRequest: {
+        method: method,
+        userAgent: userAgent,
+        remoteIp: remoteIp,
+        url: window.location.url,
+    }});
   });
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -281,33 +281,33 @@ describe('Reporting errors', function() {
       });
     });
   });
-});
 
-describe('Custom http request context', function () {
-  it('should report error messages with custom http request context', function () {
-    var method = "GET";
-    var userAgent = "bot";
-    var remoteIp = "123.45.67.89";
+  describe('Custom http request context', function() {
+    it('should report error messages with custom http request context', function() {
+      var method = 'GET';
+      var userAgent = 'bot';
+      var remoteIp = '123.45.67.89';
 
-    var httpRequestContext = {
-      method: method,
-      userAgent: userAgent,
-      remoteIp: remoteIp
-    };
+      var httpRequestContext = {
+        method: method,
+        userAgent: userAgent,
+        remoteIp: remoteIp,
+      };
 
-    var context = {
-      httpRequest: httpRequestContext
-    };
+      var context = {
+        httpRequest: httpRequestContext,
+      };
 
-    errorHandler.start({ context: context });
+      errorHandler.start({context: context});
 
-    var message = 'Something broke!';
-    return errorHandler.report(message).then(function () {
-      expectRequestWithMessage(message);
-      expectRequestWithMessage("method: " + method);
-      expectRequestWithMessage("userAgent: " + userAgent);
-      expectRequestWithMessage("remoteIp: " + remoteIp);
-      expectRequestWithMessage("url"); // specified to be window.location.href by default
+      var message = 'Something broke!';
+      return errorHandler.report(message).then(function() {
+        expectRequestWithMessage(message);
+        expectRequestWithMessage('method: ' + method);
+        expectRequestWithMessage('userAgent: ' + userAgent);
+        expectRequestWithMessage('remoteIp: ' + remoteIp);
+        expectRequestWithMessage('url'); // specified to be window.location.href by default
+      });
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -123,7 +123,7 @@ describe('Initialization', function() {
     errorHandler.start({key: 'key', projectId: 'projectId'});
     expect(errorHandler.context).to.eql({httpRequest: {
       url: window.location.url,
-      userAgent: window.navigator.userAgent
+      userAgent: window.navigator.userAgent,
     }});
   });
 
@@ -151,7 +151,8 @@ describe('Initialization', function() {
         userAgent: userAgent,
         remoteIp: remoteIp,
         url: window.location.url,
-    }});
+      },
+    });
   });
 });
 


### PR DESCRIPTION
Use `HttpRequestContext` that is passed in from `Context` during `StackdriverErrorReporter.start` method in https://github.com/GoogleCloudPlatform/stackdriver-errors-js#setup-for-javascript