### PR TITLE
Prevent "out of quota" 429 responses from report -> error looping.

### DIFF
--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -179,6 +179,15 @@ function sendErrorPayload(url, payload) {
         var code = xhr.status;
         if (code >= 200 && code < 300) {
           resolve({message: payload.message});
+        } else if (code === 429) {
+          // HTTP 429 responses are returned by Stackdriver when API quota
+          // is exceeded. We should not try to reject these as unhandled errors
+          // or we may cause an infinite loop with 'reportUncaughtExceptions'.
+          reject(
+            {
+              message: 'quota or rate limiting error on stackdriver report',
+              name: 'Http429FakeError',
+            });
         } else {
           var condition = code ? code + ' http response'  : 'network error';
           reject(new Error(condition + ' on stackdriver report'));


### PR DESCRIPTION
@steren 
General approach: don't create potentially unhandled errors when the response is an HTTP 429 Too Many Requests, since this is what Stackdriver returns when you're out of error reporting API quota.

See context in https://github.com/GoogleCloudPlatform/stackdriver-errors-js/issues/89 for the issue that this addresses.

Test fails without the fix: 
![image](https://user-images.githubusercontent.com/1621643/115925147-89612880-a435-11eb-933a-769bebe7fb5b.png)

Test passes with the fix: 
![image](https://user-images.githubusercontent.com/1621643/115925164-9120cd00-a435-11eb-8f1c-b1397edca7b4.png)