### PR TITLE
Move core-js to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -999,7 +999,8 @@
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "browser-pack-flat": "^3.4.1",
     "browserify": "^16.2.3",
     "chai": "^4.2.0",
+    "core-js": "^2.6.9",
     "eslint": "^5.16.0",
     "eslint-plugin-mocha": "^5.3.0",
     "gulp": "^3.9.1",
@@ -49,7 +50,6 @@
     "vinyl-source-stream": "^2.0.0"
   },
   "dependencies": {
-    "core-js": "^2.6.9",
     "stacktrace-js": "^2.0.0"
   }
 }


### PR DESCRIPTION
`core-js` is only used when this library is compiled to `dist` with gulp. Currently, if you install `stackdriver-errors-js` with npm/yarn, it will download `core-js` but it is not used by the library.