### PR TITLE
ES5 -> ES6

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,21 +26,12 @@ var SRC_FILE = 'stackdriver-errors.js';
 var TYPINGS_FILE = 'stackdriver-errors.d.ts';
 var DEST = 'dist/';
 
-var polyfills = [
-  'core-js/features/array/filter',
-  'core-js/features/array/for-each',
-  'core-js/features/array/map',
-  'core-js/features/function/bind',
-  'core-js/features/promise',
-];
-
 gulp.task('lib-concat', function() {
   return browserify({
     debug: true,
     entries: SRC_FILE,
     standalone: 'StackdriverErrorReporter',
   })
-    .require(polyfills)
     .plugin('browser-pack-flat/plugin')
     .bundle()
     .pipe(source(SRC_FILE))

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.8.0",
+      "name": "stackdriver-errors-js",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "stacktrace-js": "^2.0.2"
@@ -14,7 +15,6 @@
         "browser-pack-flat": "^3.4.2",
         "browserify": "^16.5.2",
         "chai": "^4.3.4",
-        "core-js": "^3.11.3",
         "eslint": "^5.16.0",
         "eslint-plugin-mocha": "^5.3.0",
         "gulp": "^4.0.2",
@@ -1695,17 +1695,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/core-js": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.3.tgz",
-      "integrity": "sha512-DFEW9BllWw781Op5KdYGtXfj3s9Cmykzt16bY6elaVuqXHCUwF/5pv0H3IJ7/I3BGjK7OeU+GrjD1ChCkBJPuA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/core-util-is": {
@@ -9858,12 +9847,6 @@
           "dev": true
         }
       }
-    },
-    "core-js": {
-      "version": "3.11.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.3.tgz",
-      "integrity": "sha512-DFEW9BllWw781Op5KdYGtXfj3s9Cmykzt16bY6elaVuqXHCUwF/5pv0H3IJ7/I3BGjK7OeU+GrjD1ChCkBJPuA==",
-      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "browser-pack-flat": "^3.4.2",
     "browserify": "^16.5.2",
     "chai": "^4.3.4",
-    "core-js": "^3.11.3",
     "eslint": "^5.16.0",
     "eslint-plugin-mocha": "^5.3.0",
     "gulp": "^4.0.2",


### PR DESCRIPTION
Drop support for ES5. Sites supporting old ES5 (IE11) probably uses polyfills anyway.

By require ES6, the bundle size can be reduced a lot.

```
ES5: 57431 bytes, stackdriver-errors-concat.min.js
ES6: 32054 bytes, stackdriver-errors-concat.min.js
```