### PR TITLE
Sync git tag and npm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stackdriver-errors-js",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "stackdriver-errors-js",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "stacktrace-js": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackdriver-errors-js",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Experimental client-side JavaScript library to report errors to Stackdriver Error Reporting",
   "main": "stackdriver-errors.js",
   "types": "stackdriver-errors.d.ts",


### PR DESCRIPTION
Latest release (git tag)  is 0.11.0, but the npm version was 0.10.0.