### PR TITLE
Send the original event to old onunhandledrejection call

### DIFF
--- a/stackdriver-errors.js
+++ b/stackdriver-errors.js
@@ -84,7 +84,7 @@ function registerHandlers(reporter) {
       if (promiseRejectionEvent) {
         reporter.report(promiseRejectionEvent.reason).catch(noop);
       }
-      oldPromiseRejectionHandler(promiseRejectionEvent.reason);
+      oldPromiseRejectionHandler(promiseRejectionEvent);
       return true;
     };
   }


### PR DESCRIPTION
Hi! Just a quick proposal:
I was checking your code and I think if we pass only the `reason` here, we can break the original handler as it would stop receiving the full event. What do you think?